### PR TITLE
Fix grouping logic

### DIFF
--- a/ZhuoHeiChaCore.Test/GameHelperTest.cs
+++ b/ZhuoHeiChaCore.Test/GameHelperTest.cs
@@ -31,13 +31,25 @@ namespace ZhuoHeiChaCore.Test
         {
             var gameHelper = new GameHelper();
 
-            // TODO: consider the case where we have Ace and then PublicAce in finish order. How should the return process be done?
-            var allDifferentPlayerTypes = new List<PlayerType> { PlayerType.Normal, PlayerType.Ace, PlayerType.PublicAce };
+            var differentPlayerTypes = new List<PlayerType> { PlayerType.Normal, PlayerType.Ace, PlayerType.Normal };
 
             var valueList = new List<int> { 0, 1, 2 };
-            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(valueList, allDifferentPlayerTypes);
+            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(valueList, differentPlayerTypes);
 
             Assert.Equal(valueList.Count, group1.Count);
+        }
+
+        [Fact]
+        public void GroupConsecutiveElementOfSameType_ShouldReturnTwoGroups_WhenThereAreBothAceAndPublicAceTogether()
+        {
+            var gameHelper = new GameHelper();
+
+            var playerTypes = new List<PlayerType> { PlayerType.Normal, PlayerType.Ace, PlayerType.PublicAce };
+
+            var valueList = new List<int> { 0, 1, 2 };
+            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(valueList, playerTypes);
+
+            Assert.Equal(2, group1.Count);
         }
 
         [Fact]

--- a/ZhuoHeiChaCore.Test/GameHelperTest.cs
+++ b/ZhuoHeiChaCore.Test/GameHelperTest.cs
@@ -94,9 +94,9 @@ namespace ZhuoHeiChaCore.Test
                 },
                 new object[]
                 {
-                    new List<int> { 3, 0, 2, 1 },
+                    new List<int> { 3, 2, 1, 0 },
                     new List<PlayerType> { PlayerType.Normal, PlayerType.Normal, PlayerType.Ace, PlayerType.Normal },
-                    new List<List<int>> { new List<int> { 3, 0 }, new List<int> { 2 }, new List<int> { 1 } }
+                    new List<List<int>> { new List<int> { 3 }, new List<int> { 2 }, new List<int> { 1, 0 } }
                 },
                 new object[]
                 {

--- a/ZhuoHeiChaCore.Test/GameHelperTest.cs
+++ b/ZhuoHeiChaCore.Test/GameHelperTest.cs
@@ -13,12 +13,17 @@ namespace ZhuoHeiChaCore.Test
         {
             var gameHelper = new GameHelper();
 
+            var allAcePlayerTypes = new List<PlayerType> { PlayerType.Ace, PlayerType.Ace, PlayerType.Ace };
+            var allNormalPlayerTypes = new List<PlayerType> { PlayerType.Normal, PlayerType.Normal, PlayerType.Normal};
+
             // selector always return the same type
-            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(new List<int> { 1, 2, 3 }, idx => PlayerType.Ace);
-            var group2 = gameHelper.GroupConsecutivePlayersOfSameType(new List<int> { 1, 4, 9 }, idx => PlayerType.PublicAce);
+            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(new List<int> { 0, 1, 2 }, allAcePlayerTypes);
+            var group2 = gameHelper.GroupConsecutivePlayersOfSameType(new List<int> { 1, 0, 2 }, allNormalPlayerTypes);
+            var group3 = gameHelper.GroupConsecutivePlayersOfSameType(new List<int> { 2, 1, 0 }, allNormalPlayerTypes);
 
             Assert.Single(group1);
             Assert.Single(group2);
+            Assert.Single(group3);
         }
 
         [Fact]
@@ -26,12 +31,25 @@ namespace ZhuoHeiChaCore.Test
         {
             var gameHelper = new GameHelper();
 
-            var valueList = new List<int> { 1, 2, 3 };
-            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(valueList, idx => (PlayerType)(idx % 2));
-            var group2 = gameHelper.GroupConsecutivePlayersOfSameType(valueList, idx => (PlayerType)idx);
+            // TODO: consider the case where we have Ace and then PublicAce in finish order. How should the return process be done?
+            var allDifferentPlayerTypes = new List<PlayerType> { PlayerType.Normal, PlayerType.Ace, PlayerType.PublicAce };
+
+            var valueList = new List<int> { 0, 1, 2 };
+            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(valueList, allDifferentPlayerTypes);
 
             Assert.Equal(valueList.Count, group1.Count);
-            Assert.Equal(valueList.Count, group2.Count);
+        }
+
+        [Fact]
+        public void GroupConsecutiveElementsOfSameType_ShouldReturnCurrectGroup_WhenFinishOrderIsRandomlyArranged()
+        {
+            var gameHelper = new GameHelper();
+
+            var valueList = new List<int> { 0, 2, 1 };
+            var typeList = new List<PlayerType> { PlayerType.Normal, PlayerType.Normal, PlayerType.Ace };
+            var group1 = gameHelper.GroupConsecutivePlayersOfSameType(valueList, typeList);
+
+            Assert.Equal(valueList.Count, group1.Count);
         }
 
         // test 1:
@@ -39,11 +57,11 @@ namespace ZhuoHeiChaCore.Test
 
         [Theory]
         [MemberData(nameof(GetTestData))]
-        public void GroupConsecutiveElementsOfSameType_ShouldGroupConsecutiveElementsOfSameType_WhenThereAreConsecutiveElementsOfSameType(List<int> valueList, List<List<int>> expectedGroups)
+        public void GroupConsecutiveElementsOfSameType_ShouldGroupConsecutiveElementsOfSameType_WhenThereAreConsecutiveElementsOfSameType(List<int> valueList, List<PlayerType> playerTypes, List<List<int>> expectedGroups)
         {
             var gameHelper = new GameHelper();
 
-            var groups = gameHelper.GroupConsecutivePlayersOfSameType(valueList, x=>(PlayerType)valueList[x]);
+            var groups = gameHelper.GroupConsecutivePlayersOfSameType(valueList, playerTypes);
 
             Assert.Equal(expectedGroups.Count, groups.Count);
             for (var i = 0; i < expectedGroups.Count; ++i)
@@ -56,11 +74,42 @@ namespace ZhuoHeiChaCore.Test
         {
             return new List<object[]>
             {
-                new object[] {new List<int> { 1,1,2,1 }, new List<List<int>> { new List<int> { 1,1 }, new List<int> { 2 }, new List<int> { 1 } } },
-                new object[] {new List<int> { 1,2,1,1 }, new List<List<int>> { new List<int> { 1 }, new List<int> { 2 }, new List<int> { 1,1 } } },
-                new object[] {new List<int> { 1,2,2,1 }, new List<List<int>> { new List<int> { 1 }, new List<int> { 2,2 }, new List<int> { 1 } } },
-                new object[] {new List<int> { 1,2,2,1,1 }, new List<List<int>> { new List<int> { 1 }, new List<int> { 2,2 }, new List<int> { 1,1 } } },
-                new object[] {new List<int> { 1,1,2,2,1,1 }, new List<List<int>> { new List<int> { 1,1 }, new List<int> { 2,2 }, new List<int> { 1,1 } } },
+                new object[]
+                {
+                    new List<int> { 0, 1, 2, 3 },
+                    new List<PlayerType> { PlayerType.Normal, PlayerType.Normal, PlayerType.Ace, PlayerType.Normal },
+                    new List<List<int>> { new List<int> { 0 ,1 }, new List<int> { 2 }, new List<int> { 3 } } 
+                },
+                new object[]
+                {
+                    new List<int> { 3, 0, 2, 1 },
+                    new List<PlayerType> { PlayerType.Normal, PlayerType.Normal, PlayerType.Ace, PlayerType.Normal },
+                    new List<List<int>> { new List<int> { 3, 0 }, new List<int> { 2 }, new List<int> { 1 } }
+                },
+                new object[]
+                {
+                    new List<int> { 0, 1, 2, 3 }, 
+                    new List<PlayerType> { PlayerType.Normal, PlayerType.Ace, PlayerType.Normal, PlayerType.Normal }, 
+                    new List<List<int>> { new List<int> { 0 }, new List<int> { 1 }, new List<int> { 2, 3 } } 
+                },
+                new object[]
+                {
+                    new List<int> { 0, 1, 2, 3 },
+                    new List<PlayerType> { PlayerType.Normal, PlayerType.Ace, PlayerType.PublicAce, PlayerType.Normal },
+                    new List<List<int>> { new List<int> { 0 }, new List<int> { 1, 2 }, new List<int> { 3 } } 
+                },
+                new object[] 
+                {
+                    new List<int> { 0, 1, 2, 3, 4 },
+                    new List<PlayerType> { PlayerType.Normal, PlayerType.Ace, PlayerType.PublicAce, PlayerType.Normal, PlayerType.Normal },
+                    new List<List<int>> { new List<int> { 0 }, new List<int> { 1, 2 }, new List<int> { 3, 4 } } 
+                },
+                new object[]
+                {
+                    new List<int> { 0, 1, 2, 3, 4, 5 },
+                    new List<PlayerType> { PlayerType.Normal, PlayerType.Normal, PlayerType.Ace, PlayerType.PublicAce, PlayerType.Normal, PlayerType.Normal },
+                    new List<List<int>> { new List<int> { 0, 1 }, new List<int> { 2, 3 }, new List<int> { 4, 5 } } 
+                },
             };
         }
     }

--- a/ZhuoHeiChaCore/Game.cs
+++ b/ZhuoHeiChaCore/Game.cs
@@ -175,7 +175,7 @@ namespace ZhuoHeiChaCore
                 && !_gameHelper.HasFourTwo(_cardsInHandByPlayerId[_finishOrder[0]]))
                 return Enumerable.Empty<(int, int)>();
 
-            var finishGroupsSequence = _gameHelper.GroupConsecutivePlayersOfSameType(_finishOrder, idx => _playerTypeList[idx]);
+            var finishGroupsSequence = _gameHelper.GroupConsecutivePlayersOfSameType(_finishOrder, _playerTypeList);
             var payerReceiverPairs = _gameHelper.GeneratePayerReceiverPairsForConsecutiveGroups(finishGroupsSequence);
 
             return payerReceiverPairs.Where(pair => !_gameHelper.HasTwoCats(_cardsInHandByPlayerId[pair.payer]));
@@ -439,13 +439,4 @@ namespace ZhuoHeiChaCore
         void AceGoPublic(int goPublicPlayerId);
         PlayHandReturn PlayHand(int playerId, List<Card> UserCard);
     }
-
-    public enum PlayerType
-    {
-        Normal,
-        Ace,
-        PublicAce
-    }
-
-
 }

--- a/ZhuoHeiChaCore/GameHelper.cs
+++ b/ZhuoHeiChaCore/GameHelper.cs
@@ -45,27 +45,29 @@ namespace ZhuoHeiChaCore
         /// <param name="values"></param>
         /// <param name="playerTypeSelector"></param>
         /// <returns></returns>
-        public List<List<T>> GroupConsecutivePlayersOfSameType<T>(List<T> values, Func<int, PlayerType> playerTypeSelector)
+        public List<List<int>> GroupConsecutivePlayersOfSameType(List<int> playerIdsByFinishOrder, List<PlayerType> playerTypesByPlayerId)
         {
-            var start = 0;
-            var current = 0;
-            var groups = new List<List<T>>();
+            var groupStartIdx = 0;
+            var currentIdx = 0;
+            var groups = new List<List<int>>();
 
-            while (current < values.Count - 1)
+            while (currentIdx < playerIdsByFinishOrder.Count - 1)
             {
-                if (playerTypeSelector(current) == playerTypeSelector(current + 1))
+                var currentPlayerId = playerIdsByFinishOrder[currentIdx];
+                var nextPlayerId = playerIdsByFinishOrder[currentIdx + 1];
+                if (playerTypesByPlayerId[currentPlayerId].IsOfSameParty(playerTypesByPlayerId[nextPlayerId]))
                 {
-                    current++;
+                    currentIdx++;
                 }
                 else
                 {
                     // we want the range to be [start, current]
-                    groups.Add(Enumerable.Range(start, current - start + 1).Select(idx => values[idx]).ToList());
-                    start = current + 1;
-                    current = start;
+                    groups.Add(Enumerable.Range(groupStartIdx, currentIdx - groupStartIdx + 1).Select(idx => playerIdsByFinishOrder[idx]).ToList());
+                    groupStartIdx = currentIdx + 1;
+                    currentIdx = groupStartIdx;
                 }
             }
-            groups.Add(Enumerable.Range(start, current - start + 1).Select(idx => values[idx]).ToList());
+            groups.Add(Enumerable.Range(groupStartIdx, currentIdx - groupStartIdx + 1).Select(idx => playerIdsByFinishOrder[idx]).ToList());
 
             return groups;
         }
@@ -87,7 +89,7 @@ namespace ZhuoHeiChaCore
     public interface IGameHelper
     {
         PlayerType GetPlayerType(List<Card> cardsOfPlayer);
-        List<List<T>> GroupConsecutivePlayersOfSameType<T>(List<T> values, Func<int, PlayerType> playerTypeSelector);
+        List<List<int>> GroupConsecutivePlayersOfSameType(List<int> playerIdsByFinishOrder, List<PlayerType> playerTypesByPlayerId);
         IEnumerable<(int payer, int receiver)> GeneratePayerReceiverPairsForConsecutiveGroups(List<List<int>> groups);
         bool HasFourTwo(List<Card> cards);
         bool HasTwoCats(List<Card> cards);

--- a/ZhuoHeiChaCore/PlayerType.cs
+++ b/ZhuoHeiChaCore/PlayerType.cs
@@ -1,0 +1,24 @@
+﻿namespace ZhuoHeiChaCore
+{
+    public enum PlayerType
+    {
+        Normal,
+        Ace,
+        PublicAce
+    }
+
+    public static class PlayerTypeExtension
+    {
+        /// <summary>
+        /// Determines if the two PlayerType objects represent the same party (BlackAce vs Normal)
+        /// </summary>
+        /// <param name="p1"></param>
+        /// <param name="p2"></param>
+        /// <returns></returns>
+        public static bool IsOfSameParty(this PlayerType p1, PlayerType p2)
+        {
+            return (p1 == PlayerType.Normal && p2 == PlayerType.Normal) 
+                || (p1 != PlayerType.Normal && p2 != PlayerType.Normal);
+        }
+    }
+}


### PR DESCRIPTION
- fixed grouping issue where it doesn't group properly for finish order {0, 2, 1} with player types {Normal, Normal, Ace}
- refactored GroupConsecutivePlayersOfSameType with more readable names and parameter types
- added/refactored unit tests for grouping logic
- refactored PlayerType enum to its own file with extension method